### PR TITLE
chore: rm unused deps from quarkus-web-template

### DIFF
--- a/scaffolder-templates/quarkus-web-template/skeleton/pom.xml
+++ b/scaffolder-templates/quarkus-web-template/skeleton/pom.xml
@@ -35,19 +35,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-container-image-s2i</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-hibernate-orm-panache</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jdbc-postgresql</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
The project contains dependencies that are not used:

- hibernate
- postgres
- container-image-s2i (not used and also deprecated)